### PR TITLE
pip: use latest docker package

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -23,4 +23,10 @@
     - python-pip
   when: ansible_os_family == "RedHat"
 
-- pip: name=docker-py version=1.9.0
+- name: python deps
+  pip: >
+    name={{item.name}}
+    state={{item.state}}
+  with_items:
+    - { name: docker-py, state: absent }
+    - { name: docker, state: present }


### PR DESCRIPTION
docker-py is not working with urllib3 1.24 and 1.24.1

```
TASK [cycloid.prometheus : Create prometheus container] ************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
fatal: [10.2.0.12]: FAILED! => {"changed": false, "msg": "Failed to import docker-py - No module named ordered_dict. Try `pip install docker-py`"}
```