### PR TITLE
HttpResponseStringMatch: allow threshold change

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,6 +90,7 @@ prometheus_telegraf_rules_config_default:
     threshold: 302
   HttpResponseStringMatch:
     name: HttpResponseStringMatch
+    threshold: 0
   LbCertsExpireCheck:
     name: LbCertsExpireCheck
     threshold: 30

--- a/templates/telegraf.rules
+++ b/templates/telegraf.rules
@@ -174,7 +174,7 @@ groups:
   {% set c = _prometheus_telegraf_rules_default_global | combine(prometheus_telegraf_rules_config_default['HttpResponseStringMatch']) | combine(user_config) %}
 
   - alert: {{ c['name'] }}
-    expr: http_response_response_string_match{ {{ c['selector'] }} } == 0
+    expr: http_response_response_string_match{ {{ c['selector'] }} } == {{ c['threshold'] }}
     for: {{ c['for'] }}
     labels:
       {% raw -%}


### PR DESCRIPTION
0 = doesn't match
1 = error when match